### PR TITLE
style: apply Texas A&M color scheme

### DIFF
--- a/_sass/_footer.scss
+++ b/_sass/_footer.scss
@@ -15,13 +15,13 @@
   height: auto;
   /* sticky footer fix end */
   margin-top: 3em;
-  color: mix(#fff, $gray, 25%);
+  color: #fff;
   -webkit-animation: intro 0.3s both;
           animation: intro 0.3s both;
   -webkit-animation-delay: 0.45s;
           animation-delay: 0.45s;
-  background-color: $lighter-gray;
-  border-top: 1px solid $light-gray;
+  background-color: $primary-color;
+  border-top: 3px solid $secondary-color;
 
   footer {
     @include clearfix;
@@ -49,7 +49,7 @@
   .fab,
   .far,
   .fal {
-    color: mix(#fff, $gray, 25%);
+    color: #fff;
   }
 }
 

--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -4,8 +4,8 @@
 
 .masthead {
   position: fixed;
-  background: white;
-  border-bottom: 1px solid $border-color;
+  background: $primary-color;
+  border-bottom: 3px solid $secondary-color;
   height: $masthead-height;
   top: 0;
   width: 100%;
@@ -32,6 +32,7 @@
 
     a {
       text-decoration: none;
+      color: $masthead-link-color;
     }
   }
 }

--- a/_sass/_navigation.scss
+++ b/_sass/_navigation.scss
@@ -175,7 +175,7 @@
 .greedy-nav {
   position: relative;
   min-width: 250px;
-  background: $background-color;
+  background: $primary-color;
 
   a {
     display: block;

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -68,7 +68,8 @@ $code-background-color-dark : $light-gray;
 $text-color                 : $dark-gray;
 $border-color               : $lighter-gray;
 
-$primary-color              : #7a8288;
+$primary-color              : #500000;
+$secondary-color            : #707373;
 $success-color              : #62c462;
 $warning-color              : #f89406;
 $danger-color               : #ee5f5b;
@@ -105,8 +106,8 @@ $xing-color                 : #006567;
 $link-color                 : $info-color;
 $link-color-hover           : mix(#000, $link-color, 25%);
 $link-color-visited         : mix(#fff, $link-color, 25%);
-$masthead-link-color        : $primary-color;
-$masthead-link-color-hover  : mix(#000, $primary-color, 25%);
+$masthead-link-color        : #fff;
+$masthead-link-color-hover  : lighten($primary-color, 15%);
 
 
 /*


### PR DESCRIPTION
## Summary
- use Texas A&M maroon and gray as primary colors
- update masthead, navigation, and footer to adopt new palette

## Testing
- `npm run build:js`
- `bundle exec jekyll build` *(fails: command not found)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_b_68ae1da6a42483208bdb47c3dcc6f0de