### PR TITLE
Enable Google Analytics 4

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -146,9 +146,9 @@ social:
 
 # Analytics
 analytics:
-  provider               :  "false" # false (default), "google", "google-universal", "google-analytics-4", "custom"
+  provider               :  "google-analytics-4" # false (default), "google", "google-universal", "google-analytics-4", "custom"
   google:
-    tracking_id          :
+    tracking_id          : "G-ZH6R1WVBPR"
 
 
 # Reading Files


### PR DESCRIPTION
## Summary
- Configure site analytics to use Google Analytics 4 with measurement ID `G-ZH6R1WVBPR`

## Testing
- `bundle exec jekyll build` *(fails: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_b_68b0a383dc9083208e9d6e33838b4891